### PR TITLE
Dodana spremenljivka MIDDLEWARE_CLASSES

### DIFF
--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -51,6 +51,8 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+MIDDLEWARE_CLASSES = MIDDLEWARE
+
 ROOT_URLCONF = 'recipes.urls'
 
 TEMPLATES = [


### PR DESCRIPTION
Pri meni ni delovala prijava - očitno gre za razlike v različicah Djanga (jaz imam 1.9.5). Prosim, da preverite, če vam vse še vedno deluje.